### PR TITLE
Removed import of misinformation/notebooks directory 

### DIFF
--- a/textattack/misinformation/__init__.py
+++ b/textattack/misinformation/__init__.py
@@ -7,6 +7,3 @@ TextAttack misinformation Package
 
 from .entity_extraction import EntityExtraction
 
-from . import (
-    notebooks
-)


### PR DESCRIPTION
This PR was motivated by a circular reference in the creation of the wheel file. 